### PR TITLE
Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git://github.com/mike-goodwin/connect-azuretables.git"
   },
   "dependencies": {
-    "azure-storage": "2.0.0",
+    "azure-storage": "2.2.1",
     "cron": "1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As far as I tested, connect-azuretables works with azure-storage 2.2.1.
 
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>